### PR TITLE
Modify catalog builder pre-parser

### DIFF
--- a/Tools/Catalog-Builder/catalog_builder/utils.py
+++ b/Tools/Catalog-Builder/catalog_builder/utils.py
@@ -19,6 +19,7 @@ def pre_parser(text):
 
     Namely, 1) add extra line before bullet points and
     2) use four spaces instead of two to signal a sub-bullet point
+    3) add an indent to signal a third-tier bullet point
 
     """
     doc_list = text.splitlines()
@@ -27,12 +28,14 @@ def pre_parser(text):
 
     counter = -1
 
-    for line in doc_list:
+    for line in c_list:
         counter += 1
-        if line.startswith("- "):
-            list_edit[counter - 1] = doc_list[counter - 1] + '\n'
-        elif line.startswith("  *"):
-            list_edit[counter] = "  " + doc_list[counter]
+        if line.startswith("* ") or line.startswith("- "):
+            list_edit[counter - 1] = c_list[counter - 1] + '\n'
+        elif line.startswith("  *") or line.startswith("  -"):
+            list_edit[counter] = "  " + c_list[counter]
+        elif line.startswith("    *") or line.startswith("    -"):
+            list_edit[counter] = '\t' + c_list[counter] 
 
     string_edit = "\n".join(list_edit)
 

--- a/Tools/Catalog-Builder/catalog_builder/utils.py
+++ b/Tools/Catalog-Builder/catalog_builder/utils.py
@@ -19,7 +19,7 @@ def pre_parser(text):
 
     Namely, 1) add extra line before bullet points and
     2) use four spaces instead of two to signal a sub-bullet point
-    3) add an indent to signal a third-tier bullet point
+    3) add indent to signal third-tier bullet point
 
     """
     doc_list = text.splitlines()
@@ -28,14 +28,14 @@ def pre_parser(text):
 
     counter = -1
 
-    for line in c_list:
+    for line in doc_list:
         counter += 1
         if line.startswith("* ") or line.startswith("- "):
-            list_edit[counter - 1] = c_list[counter - 1] + '\n'
+            list_edit[counter - 1] = doc_list[counter - 1] + '\n'
         elif line.startswith("  *") or line.startswith("  -"):
-            list_edit[counter] = "  " + c_list[counter]
+            list_edit[counter] = "  " + doc_list[counter]
         elif line.startswith("    *") or line.startswith("    -"):
-            list_edit[counter] = '\t' + c_list[counter] 
+            list_edit[counter] = '\t' + doc_list[counter]         
 
     string_edit = "\n".join(list_edit)
 


### PR DESCRIPTION
This PR modifies the catalog builder pre-parser to be more inclusive of different types of bullet points. These issues came to my attention when running the catalog builder on the B-Tax json file.

Namely, bullet points can be denoted by `* ` or `- ` in markdown and third-tier bullet points require an extra indent to be rendered as such.

@MattHJensen @martinholmer @andersonfrailey @hdoupe 