### PR TITLE
Add Google Analytics

### DIFF
--- a/Tools/Catalog-Builder/templates/model_template.html
+++ b/Tools/Catalog-Builder/templates/model_template.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>PSL Models</title>
         <!-- include bootstrap -->

--- a/Tools/Catalog-Builder/templates/models_template.html
+++ b/Tools/Catalog-Builder/templates/models_template.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>PSL Models</title>
         <!-- include bootstrap -->

--- a/Tools/Page-Builder/page_builder/pages.json
+++ b/Tools/Page-Builder/page_builder/pages.json
@@ -8,5 +8,5 @@
         "template": null,
         "content": "../../../NEWS.md",
         "pathout": "../../Web/pages/news.html"
-    },
+    }
 }

--- a/Tools/Page-Builder/page_builder/tests/TestFiles/testpage.html
+++ b/Tools/Page-Builder/page_builder/tests/TestFiles/testpage.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>Test Page</title>
         <!-- include bootstrap -->
@@ -22,10 +31,8 @@
                 <a href="../../../index.html" class="navbar-brand">Policy Simulation Library</a>
             </div>
             <ul class="navbar-nav">
+                <li class="nav-item"><a href="catalog.html" class="nav-link">Catalog</a></li>
                 <li class="nav-item"><a href="about.html" class="nav-link">About PSL</a></li>
-                <li class="nav-item"><a href="models.html" class="nav-link">Models</a></li>
-                <!-- <li class="nav-item"><a href="donate.html" class="nav-link">Donate</a></li>
-                <li class="nav-item"><a href="faq.html" class="nav-link">FAQ</a></li> -->
             </ul>
         </nav>
         <div class="container" id="content">

--- a/Tools/Page-Builder/templates/page_template.html
+++ b/Tools/Page-Builder/templates/page_template.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>{{ title }}</title>
         <!-- include bootstrap -->

--- a/Tools/Web/pages/about.html
+++ b/Tools/Web/pages/about.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>About</title>
         <!-- include bootstrap -->
@@ -34,7 +43,7 @@
 <li>A PSL-Catalog of projects and their key attributes, which is automatically constructed by PSL-Core's Catalog-Builder tool. </li>
 <li>The policysimulationlibrary.org website to host general Library information and the PSL-Catalog.</li>
 <li>Broadcast-Recipes for disseminating updates about the projects to users. </li>
-<li>A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."</li>
+<li>A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know <strong>_</strong>."</li>
 </ul>
 <p>If you would like to learn more about PSL plans, see our <a href="https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md">roadmap</a>. </p>
 <p>If you would like to make a technical contribution to PSL, please review the <a href="https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md">contributor guide</a>. </p>

--- a/Tools/Web/pages/catalog.html
+++ b/Tools/Web/pages/catalog.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>PSL Models</title>
         <!-- include bootstrap -->

--- a/Tools/Web/pages/news.html
+++ b/Tools/Web/pages/news.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>News</title>
         <!-- include bootstrap -->

--- a/Tools/Web/pages/projects/B-Tax.html
+++ b/Tools/Web/pages/projects/B-Tax.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>PSL Models</title>
         <!-- include bootstrap -->

--- a/Tools/Web/pages/projects/OG-USA.html
+++ b/Tools/Web/pages/projects/OG-USA.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>PSL Models</title>
         <!-- include bootstrap -->

--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
         <meta charset="utf-8">
         <title>PSL Home</title>
         <!-- include bootstrap -->


### PR DESCRIPTION
This PR adds Google analytics to all of the web pages and updates the templates so that they will include the needed scripts in each of the HTML files that are produced using them.

@Peter-Metz @hdoupe @MattHJensen 