### PR TITLE
make model submission process transparent

### DIFF
--- a/Community/contribute.md
+++ b/Community/contribute.md
@@ -4,7 +4,7 @@ You are welcome to contribute to PSL by making a technical contribution to PSL i
 
 When you feel that you have made a valuable contribution, please add it to RELEASES.md. If you think PSL users should know about it, add it to NEWS.md. If your name is not already in contributors.md, add it.
 
-To submit your model to PSL, please bring your model into compliance with [PSL Criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) and then open a pull request to PSL adding your model to the [PSL Catalog Register](https://github.com/open-source-economics/PSL/blob/master/Catalog/register.json). The PSL project will then review your PR. If you have a question about this process, please open an [issue](https://github.com/open-source-economics/PSL/issues). 
+To submit a public policy simulation project to PSL, please bring your model or data preparation routine into compliance with [PSL Criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) and then open a pull request to PSL adding your model to the [PSL Catalog Register](https://github.com/open-source-economics/PSL/blob/master/Catalog/register.json). The PSL project will then review your PR. If you have a question about the process or are unsure of your project's relevance to PSL, please open an [issue](https://github.com/open-source-economics/PSL/issues). 
 
 while each model in the library will have its own set of instructions for contributing.
 You can view each model in the [catalog](www.policysimulationlibrary.org/catalog) for

--- a/Community/contribute.md
+++ b/Community/contribute.md
@@ -4,10 +4,10 @@ You are welcome to contribute to PSL by making a technical contribution to PSL i
 
 When you feel that you have made a valuable contribution, please add it to RELEASES.md. If you think PSL users should know about it, add it to NEWS.md. If your name is not already in contributors.md, add it.
 
-To nominate a model for the library, contact librarian Matt Jensen (matt.h.jensen@gmail.com). 
+To submit your model to PSL, please bring your model into compliance with [PSL Criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) and then open a pull request to PSL adding your model to the [PSL Catalog Register](https://github.com/open-source-economics/PSL/blob/master/Catalog/register.json). The PSL project will then review your PR. If you have a question about this process, please open an [issue](https://github.com/open-source-economics/PSL/issues). 
 
 while each model in the library will have its own set of instructions for contributing.
-You can view each model in the [catalog](catalog.html) for
+You can view each model in the [catalog](www.policysimulationlibrary.org/catalog) for
 specific instructions on contributing.
 
 ## Office hours with the community

--- a/Community/contribute.md
+++ b/Community/contribute.md
@@ -6,10 +6,6 @@ When you feel that you have made a valuable contribution, please add it to RELEA
 
 To submit a public policy simulation project to PSL, please bring your model or data preparation routine into compliance with [PSL Criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) and then open a pull request to PSL adding your model to the [PSL Catalog Register](https://github.com/open-source-economics/PSL/blob/master/Catalog/register.json). The PSL project will then review your PR. If you have a question about the process or are unsure of your project's relevance to PSL, please open an [issue](https://github.com/open-source-economics/PSL/issues). 
 
-while each model in the library will have its own set of instructions for contributing.
-You can view each model in the [catalog](www.policysimulationlibrary.org/catalog) for
-specific instructions on contributing.
-
 ## Office hours with the community
 
 --------------------------------


### PR DESCRIPTION
After thinking on this further, I prefer a transparant, public, approach to model submissions, rather than requiring that private emails be sent to me. 

@hdoupe, could you suggest an addition to the new blurb about adding `PSL_catalog.json` to the applying project repo?  