### PR TITLE
Adds PSL_catalog.json to the PSL criteria

### DIFF
--- a/Criteria/library_criteria.md
+++ b/Criteria/library_criteria.md
@@ -5,14 +5,14 @@ Policy Simulation Library Project Criteria
 Summary
 -------
 
-1. Models must be transparant.   
-1. Interface recommendations fascilitate interoperability. 
-1. Organizational recommendations fascilitate community.  
+1. Models must be transparant.
+1. Interface recommendations fascilitate interoperability.
+1. Organizational recommendations fascilitate community.
 
 Introduction
 -------------
 
-Open-source modeling ensures that model results are reproducible, that experts around the world can collaborate to make models better, and that users can explore the parameter space for themselves. These outcomes systematically improve public policy decisionmaking. 
+Open-source modeling ensures that model results are reproducible, that experts around the world can collaborate to make models better, and that users can explore the parameter space for themselves. These outcomes systematically improve public policy decisionmaking.
 
 We have developed the criteria in this document to fascilitate the growth of an open source public policy modeling ecosystem.
 
@@ -20,52 +20,52 @@ Criteria
 ---------
 PSL establishes three kinds of project Criteria. A project are required to (`MUST`) conform to `Acceptance Criteria` to be accepted in PSL. Projects are recommended to (`SHOULD`) or optionally (`MAY`) conform to various `Community Criteria` and `Interoperability Criteria`.
 
-Acceptance Criteria for Transparancy and Quality 
+Acceptance Criteria for Transparancy and Quality
 --------------------------------------------
 
 1. Models MUST be released under an OSI-approved open source license or the Creative Commons Public Domain Dedication (CC0).
-1. Data MUST be publicly available, unless release is restricted by a third party. 
+1. Data MUST be publicly available, unless release is restricted by a third party.
 1. For any data that SHOULD not be disclosed, provided MUST be:
-	- A complete descriptive list of all data variables; 
+	- A complete descriptive list of all data variables;
 	- Descriptive statistics for all data variables for such data (including averages, standard deviations, number of observations, and correlations to other variables), to the extent that the descriptive statistics do not violate the rule against disclosure;
-	- Contact information for the individual or entity who has unrestricted access to the data. 
-1. At least one test MUST generate key outputs from source materials, the test MUST be run with every new version, and the outputs of the test MUST be checked into the repository. 
-1. Projects MUST have unit tests and SHOULD report code coverage. 
-1. Projects MUST report names and contact information for at least one maintainer. 
-1. Projects MUST have a suggested citation. 
-1. Projects MUST have a project overview. 
-1. Projects MUST have installation directions. 
+	- Contact information for the individual or entity who has unrestricted access to the data.
+1. At least one test MUST generate key outputs from source materials, the test MUST be run with every new version, and the outputs of the test MUST be checked into the repository.
+1. Projects MUST have unit tests and SHOULD report code coverage.
+1. Projects MUST report names and contact information for at least one maintainer.
+1. Projects MUST have a suggested citation.
+1. Projects MUST have a project overview.
+1. Projects MUST have installation directions.
 1. Project MUST be mirrored in the same GitHub organization as PSL, and therefore they MUST be under version control.
-1. Projects MUST use a consistent versioning scheme, which SHOULD be [semantic versioning][1]. 
+1. Projects MUST use a consistent versioning scheme, which SHOULD be [semantic versioning][1].
 
 Community Criteria
 -------------------
 
 1. Projects SHOULD have a public roadmap.
-1. Projects SHOULD have contributor documentation and guidelines. 
-1. Projects SHOULD have regular office hours, webinars, or standing meetings. 
-1. Projects SHOULD list technical contributors. 
-1. Projects SHOULD list funders. 
-1. Projects SHOULD list user citations and case studies. 
-1. Projects SHOULD include subject matter tags, chosing from ...  
-1. Projects SHOULD include a disclaimer. 
+1. Projects SHOULD have contributor documentation and guidelines.
+1. Projects SHOULD have regular office hours, webinars, or standing meetings.
+1. Projects SHOULD list technical contributors.
+1. Projects SHOULD list funders.
+1. Projects SHOULD list user citations and case studies.
+1. Projects SHOULD include subject matter tags, chosing from ...
+1. Projects SHOULD include a disclaimer.
 1. Projects SHOULD have a public issues tracker.
-1. Projects SHOULD have a changelog. 
-1. Projects MAY have a Stack Overflow channel. 
-1. Projects MAY include a "News" translation of the changelog for users. 
-1. Projects MAY include criteria for participating in cross-model PSL initiatives. 
-1. Projects MAY include a link to a webapp verison. 
-1. Projects MAY include a list of consultants. 
+1. Projects SHOULD have a changelog.
+1. Projects MAY have a Stack Overflow channel.
+1. Projects MAY include a "News" translation of the changelog for users.
+1. Projects MAY include criteria for participating in cross-model PSL initiatives.
+1. Projects MAY include a link to a webapp verison.
+1. Projects MAY include a list of consultants.
 
 
 Interoperability Criteria
 --------------------------
 
-1. The source code SHOULD be written in an open source language. 
+1. The source code SHOULD be written in an open source language.
 1. All input and output variables SHOULD be documented like...
 1. All policy parameters and assumptions SHOULD be documented like...
-1. Meta information about your project SHOULD be documenteded like... 
-1. A configuration file, like...SHOULD identify the location of these materials in your repository. 
+1. Meta information about your project SHOULD be documenteded like...
+1. A configuration file, like...SHOULD identify the location of these materials in your repository.
 
 
 

--- a/Criteria/library_criteria.md
+++ b/Criteria/library_criteria.md
@@ -65,10 +65,11 @@ Interoperability Criteria
 1. All input and output variables SHOULD be documented like...
 1. All policy parameters and assumptions SHOULD be documented like...
 1. Meta information about your project SHOULD be documenteded like...
-1. A configuration file, like...SHOULD identify the location of these materials in your repository.
+1. A `PSL_catalog.json` configuration file to be used for cataloging these criteria MUST be included in the project's repository. Specifc instructions for creating this file can be found in the [Catalog-Builder Documentation][2].
 
 
 
 
 
 [1]: https://semver.org/
+[2]: https://github.com/open-source-economics/PSL/tree/master/Tools/Catalog-Builder#catalog-specification-file-psl_catalogjson

--- a/Tools/Catalog-Builder/README.md
+++ b/Tools/Catalog-Builder/README.md
@@ -73,10 +73,10 @@ Currently, data for each project attribute can be specified on github or directl
   - "source" can optionally be set to a webpage where this data can be verified or more information about it can be found.
   - "start_header" and "end_header" are ignored in this case.
 
-Allowed attributes and their display names:
+Attributes that MUST be included:
   - `project_one_line`: NA
-  - `key_features`: Key Features,
   - `project_overview`: Project Overview,
+  - `key_features`: Key Features
   - `citation`: Citation,
   - `license`: License,
   - `user_documentation`: User Documentation,
@@ -93,6 +93,9 @@ Allowed attributes and their display names:
   - `link_to_webapp`: Link to webapp,
   - `public_issue_tracker`: Public Issue Tracker,
   - `public_qanda`: Public Q & A
+  - `core_maintainers`: Core Maintainers
+  - `unit_test`: Unit Tests
+  - `integration_test`: Integration Tests
 
 See examples here:
 - [`OG-USA/PSL_catalog.json`][]

--- a/Tools/Catalog-Builder/README.md
+++ b/Tools/Catalog-Builder/README.md
@@ -33,7 +33,7 @@ Note: We can add support for other version control repositories upon request.
 
 2. Create a `PSL_catalog.json` file according to the schema below
 
-Catalog specification file: `PSL_catalog.json`
+Catalog configuration file: `PSL_catalog.json`
 -----------------------------------------------
 The purpose of the project's `PSL_catalog.json` file is to help the catalog builder locate information about the project. This information will be stored in the PSL catalog and rendered on the project's PSL page. The basic layout of this file looks like this:
 

--- a/Tools/Catalog-Builder/README.md
+++ b/Tools/Catalog-Builder/README.md
@@ -95,11 +95,11 @@ Allowed attributes and their display names:
   - `public_qanda`: Public Q & A
 
 See examples here:
-- [`TestProject/PSL_catalog.json`][]
+- [`OG-USA/PSL_catalog.json`][]
 - [`Tax-Calculator/PSL_catalog.json`][]
 
 
 
 
-[`TestProject/PSL_catalog.json`]: catalog_builder/tests/TestProject/PSL_catalog.json
-[`Tax-Calculator/PSL_catalog.json`]: https://github.com/hdoupe/Tax-Calculator/blob/psl-catalog/PSL_catalog.json
+[`OG-USA/PSL_catalog.json`]: https://github.com/open-source-economics/OG-USA/blob/master/PSL_catalog.json
+[`Tax-Calculator/PSL_catalog.json`]: https://github.com/open-source-economics/Tax-Calculator/blob/master/PSL_catalog.json

--- a/Tools/Catalog-Builder/catalog_builder/catalog.py
+++ b/Tools/Catalog-Builder/catalog_builder/catalog.py
@@ -14,7 +14,7 @@ class CatalogBuilder:
     dumped into a JSON file `catalog.json` and into HTML templates to be
     served on the web.
 
-    Catalog metadata schema:
+    Catalog configuration file (PSL_catalog.json) schema:
 
     {
         'attribute': {


### PR DESCRIPTION
I have a couple of questions:
- are we OK with calling the `PSL_catalog.json` a configuration file?
  - if so, I'll swap the name in the docs from specifications file to configuration file to be consistent
- is the [section](https://github.com/open-source-economics/PSL/tree/master/Tools/Catalog-Builder#catalog-specification-file-psl_catalogjson) on the `PSL_catalog.json` file in the `Catalog-Builder/README.md` document the right place to link to?

Also, my text editor trimmed a bunch of spaces on the `library_criteria.md` document. I tried to isolate those to the first commit. The second commit contains only the changes that I made.

cc @MattHJensen @andersonfrailey 