### PR TITLE
Update contributors.md

### DIFF
--- a/Community/contributors.md
+++ b/Community/contributors.md
@@ -1,4 +1,4 @@
-This document lists contributors to the Policy Simulation library, but not to library models.
+This document lists contributors to the Policy Simulation library.
 
 Technical contributors
 ----------------------- 
@@ -9,4 +9,10 @@ Technical contributors are individuals who have made significant contributions t
 - Hank Doupe
 - Peter Metz
 - Martin Holmer
+- Jeniffer Morretta
+- Contributors to OG-USA
+- Contributors to Tax-Calculator
+- Contributors to B-Tax
+
+
 


### PR DESCRIPTION
It was awkward drawing a distinction between contributors to PSL and contributors to projects in PSL, so this commit gives credit to all contributors to each PSL project on a single line for each project: e.g., "Contributors to Tax-Calculator." 