### PR TITLE
Update PSL homepage with text from NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
 NEWS
 ----
 
-11.02.18: The Policy Simulation Library is live with v.0.1.0, including a contributor guide, release process, roadmap, a PSL logo, and infrastructure for a PSL catalog and website. Three new modeling projects joined PSL: Tax-Calculator, B-Tax, and OG-USA. www.policysimulationlibrary.org.
+11.02.18: The Policy Simulation Library is live with v.0.1.0, including a contributor guide, release process, roadmap, a PSL logo, and infrastructure for a PSL catalog and website. Three new modeling projects joined PSL: Tax-Calculator, B-Tax, and OG-USA. www.pslmodels.org.

--- a/Tools/Page-Builder/page_builder/pagebuilder.py
+++ b/Tools/Page-Builder/page_builder/pagebuilder.py
@@ -1,5 +1,6 @@
 import markdown
 import json
+from bs4 import BeautifulSoup
 from jinja2 import Template
 
 
@@ -53,7 +54,12 @@ class PageBuilder():
             # read and convert markdown content to HTML
             with open(content, 'r') as f:
                 md_text = f.read()
-            html_text = markdown.markdown(md_text)
+            if page == "Homepage":
+                html_text = markdown.markdown(md_text)
+                soup = BeautifulSoup(html_text, 'lxml')
+                html_text = soup.p
+            else:
+                html_text = markdown.markdown(md_text)
             self.write_page(pathout, template,
                             title=title, content=html_text)
 

--- a/Tools/Page-Builder/page_builder/pages.json
+++ b/Tools/Page-Builder/page_builder/pages.json
@@ -8,5 +8,10 @@
         "template": null,
         "content": "../../../NEWS.md",
         "pathout": "../../../news.html"
+    },
+    "Homepage": {
+        "template": "../templates/index_template.html",
+        "content": "../../../NEWS.md",
+        "pathout": "../../../index.html"
     }
 }

--- a/Tools/Page-Builder/templates/index_template.html
+++ b/Tools/Page-Builder/templates/index_template.html
@@ -64,7 +64,7 @@
                                 News
                             </div>
                             <div class="card-body">
-                                <p>11.02.18: The Policy Simulation Library is live with v.0.1.0, including a contributor guide, release process, roadmap, a PSL logo, and infrastructure for a PSL catalog and website. Three new modeling projects joined PSL: Tax-Calculator, B-Tax, and OG-USA. www.policysimulationlibrary.org.</p>
+                                {{ content }}
                             </div>
                         </div>
                     </a>

--- a/about.html
+++ b/about.html
@@ -43,7 +43,7 @@
 <ul>
 <li>A PSL-Catalog of projects and their key attributes, which is automatically constructed by PSL-Core's Catalog-Builder tool. </li>
 <li>The policysimulationlibrary.org website to host general Library information and the PSL-Catalog.</li>
-<li>Broadcast-Recipes for disseminating updates about the projects to users. </li>
+<li>Broadcast-Recipes for disseminating updates about the projects to users.</li>
 <li>A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."</li>
 </ul>
 <p>If you would like to learn more about PSL plans, see our <a href="https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md">roadmap</a>. </p>

--- a/about.html
+++ b/about.html
@@ -44,7 +44,7 @@
 <li>A PSL-Catalog of projects and their key attributes, which is automatically constructed by PSL-Core's Catalog-Builder tool. </li>
 <li>The policysimulationlibrary.org website to host general Library information and the PSL-Catalog.</li>
 <li>Broadcast-Recipes for disseminating updates about the projects to users. </li>
-<li>A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know <strong>_</strong>."</li>
+<li>A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."</li>
 </ul>
 <p>If you would like to learn more about PSL plans, see our <a href="https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md">roadmap</a>. </p>
 <p>If you would like to make a technical contribution to PSL, please review the <a href="https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md">contributor guide</a>. </p>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                                 News
                             </div>
                             <div class="card-body">
-                                <p>11.02.18: The Policy Simulation Library is live with v.0.1.0, including a contributor guide, release process, roadmap, a PSL logo, and infrastructure for a PSL catalog and website. Three new modeling projects joined PSL: Tax-Calculator, B-Tax, and OG-USA. www.policysimulationlibrary.org.</p>
+                                <p>11.02.18: The Policy Simulation Library is live with v.0.1.0, including a contributor guide, release process, roadmap, a PSL logo, and infrastructure for a PSL catalog and website. Three new modeling projects joined PSL: Tax-Calculator, B-Tax, and OG-USA. www.pslmodels.org.</p>
                             </div>
                         </div>
                     </a>

--- a/news.html
+++ b/news.html
@@ -37,7 +37,8 @@
             </ul>
         </nav>
         <div class="container" id="content">
-            <p>NEWS.md is a general-audience version of RELEASES.md. Ideally news items are summarizes in 280 charachters for Twitter. </p>
+            <h2>NEWS</h2>
+<p>11.02.18: The Policy Simulation Library is live with v.0.1.0, including a contributor guide, release process, roadmap, a PSL logo, and infrastructure for a PSL catalog and website. Three new modeling projects joined PSL: Tax-Calculator, B-Tax, and OG-USA. www.pslmodels.org.</p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This PR is in response to issue [#60](https://github.com/open-source-economics/PSL/issues/60)

Page-builder now pulls text from `NEWS.md` when it creates `index.html` so that `index.html` does not have to be manually updated each time there is a new news item. One caveat to the way things are currently structured: if someone wanted to make changes to the PSL homepage, they would have to make changes to `Tools/Page-Builder/templates/index_template.html` as opposed to `index.html` directly so that their changes are not overridden when `pagebuilder.py` is run.

Do you think this will pose a problem?

@MattHJensen @andersonfrailey @hdoupe