### PR TITLE
Add link to PSL chat room in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ If you would like to learn more about PSL plans, see our [roadmap](https://githu
 
 If you would like to make a technical contribution to PSL, please review the [contributor guide](https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md).
 
-You can reach PSL developers to discuss how to get started by opening an issue or joining the PSL Community [chat room](https://matrix.to/#/!oZnjlINzAXrgdzXEfZ:matrix.org).
+You can reach PSL developers and users to discuss how to get started by opening an issue or joining the PSL Community [chat room](https://matrix.to/#/!oZnjlINzAXrgdzXEfZ:matrix.org).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) for transparancy. Modeling projects may also adopt PSL's criteria for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains. 
+The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) for transparancy. Modeling projects may also adopt PSL's criteria for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains.
 
-The PSL project, which lives in this repository, sets PSL criteria and develops infrastructure to support PSL. 
+The PSL project, which lives in this repository, sets PSL criteria and develops infrastructure to support PSL.
 
 PSL infrastructure projects under development include:
 
-- A PSL-Catalog of projects and their key attributes, which is automatically constructed by PSL-Core's Catalog-Builder tool. 
+- A PSL-Catalog of projects and their key attributes, which is automatically constructed by PSL-Core's Catalog-Builder tool.
 - The policysimulationlibrary.org website to host general Library information and the PSL-Catalog.
-- Broadcast-Recipes for disseminating updates about the projects to users. 
+- Broadcast-Recipes for disseminating updates about the projects to users.
 - A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."
 
-If you would like to learn more about PSL plans, see our [roadmap](https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md). 
+If you would like to learn more about PSL plans, see our [roadmap](https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md).
 
-If you would like to make a technical contribution to PSL, please review the [contributor guide](https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md). 
-
+If you would like to make a technical contribution to PSL, please review the [contributor guide](https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md).

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ PSL infrastructure projects under development include:
 If you would like to learn more about PSL plans, see our [roadmap](https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md).
 
 If you would like to make a technical contribution to PSL, please review the [contributor guide](https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md).
+
+You can reach PSL developers to discuss how to get started by opening an issue or joining the PSL Community [chat room](https://matrix.to/#/!oZnjlINzAXrgdzXEfZ:matrix.org).


### PR DESCRIPTION
This PR adds a link to the PSL chat room in the README file. As I [stated yesterday][1], @MattHJensen, @Peter-Metz, @andersonfrailey, and I have been using the PSL chat room for about a month and a half now. I've enjoyed having the option to communicate over chat, and I've enjoyed the free and open-source [Riot chat application][2]. I hope adding a link to the README makes it more apparent that chat is one of several ways that people can engage with the PSL community.
 
[1]: https://github.com/open-source-economics/PSL/issues/9#issuecomment-436753485
[2]: https://about.riot.im/