### PR TITLE
Add Behavioral-Responses model to and update PSL Catalog 

### DIFF
--- a/Catalog/Behavioral-Responses.html
+++ b/Catalog/Behavioral-Responses.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+    <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-128365658-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-128365658-1');
+        </script>
+        <meta charset="utf-8">
+        <title>PSL Models</title>
+        <!-- include bootstrap -->
+        <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <style>
+        .model-info a {
+            color:inherit;
+            text-decoration-line: underline;
+            text-decoration-style: solid;
+        }
+        .jumbotron {
+            background-color: transparent !important;
+        }
+        /* github style code highlighting */
+        code {
+            color: inherit;
+            background-color: rgba(27,31,35,0.05);
+        }
+    </style>
+    <body>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+            <div class="navbar-header">
+                <a href="../index.html" class="navbar-brand">Policy Simulation Library</a>
+            </div>
+            <ul class="navbar-nav">
+                <!-- TODO: Need better solution to relative path here -->
+                <li class="nav-item"><a href="index.html" class="nav-link">Catalog</a></li>
+                <li class="nav-item"><a href="../about.html" class="nav-link">About PSL</a></li>
+            </ul>
+        </nav>
+
+        <div class="container">
+            <div class="jumbotron model-info">
+                <h1 class="display-4">Behavioral-Responses</h1>
+                <p class="lead"><p>Partial-equilibrium behavioral-responses module that works with Tax-Calculator</p></p>
+                <hr class="my-4">
+                
+                    
+                
+                    
+                        <h4> Project Overview</h4>
+                        <p><p>Behavioral-Responses, which is part of the Policy Simulation Library (PSL) collection of USA tax models, estimates partial-equilibrium behavioral responses to changes in the US federal individual income and payroll tax system as simulated by <a href="https://github.com/open-source-economics/Tax-Calculator">Tax-Calculator</a></p> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Citation</h4>
+                        <p><p>Please cite the source of your analysis as "Behavioral-Responses release #.#.#, author's calculations." If you wish to link to Behavioral-Responses, https://open-source-economics.github.io/Behavioral-Responses/ is preferred.  Additionally, we strongly recommend that you describe the elasticity assumptions used, and provide a link to the materials required to replicate your analysis or, at least, note that those materials are available upon request.</p> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> License</h4>
+                        <p><p>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</p> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/LICENSE.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> User Documentation</h4>
+                        <p><a href="http://open-source-economics.github.io/Behavioral-Responses/index.html">http://open-source-economics.github.io/Behavioral-Responses/index.html</a> </p>
+                        
+                    
+                
+                    
+                
+                    
+                
+                    
+                        <h4> Developer Changelog</h4>
+                        <p><p>Go <a href="https://github.com/open-source-economics/Behavioral-Responses/pulls?q=is%3Apr+is%3Aclosed">here</a> for a complete commit history.</p> <h5>2018-11-13 Release 0.4.0</h5> <p>(last merged pull request is <a href="https://github.com/open-source-economics/Behavioral-Responses/pull/21">#21</a>)</p> <p><strong>API Changes</strong></p> <ul> <li> <p>Change documentation to state that Behavioral-Responses <code>behresp</code> packages are available <strong>only</strong> via the <code>PSLmodels</code> Anaconda Cloud channel   [<a href="https://github.com/open-source-economics/Behavioral-Responses/pull/20">#20</a>   by Martin Holmer]</p> </li> <li> <p>Remove <code>versioneer.py</code> and <code>taxcalc/_version.py</code> and related code now that Package-Builder is handling version specification   [<a href="https://github.com/open-source-economics/Behavioral-Responses/pull/21">#21</a>   by Martin Holmer]</p> </li> </ul> <p><strong>New Features</strong></p> <ul> <li>None</li> </ul> <p><strong>Bug Fixes</strong></p> <ul> <li>None</li> </ul> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Disclaimer</h4>
+                        <p><p>Results will change as the underlying models improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                
+                    
+                
+                    
+                        <h4> Core Maintainers</h4>
+                        <p><ul><li>Martin Holmer</li><li>Matt Jensen</li></ul> </p>
+                        
+                    
+                
+                    
+                        <h4> Contributor Overview</h4>
+                        <p><p>If you want to <strong>report a bug</strong>, create a new issue <a href="https://github.com/open-source-economics/Behavioral-Responses/issues">here</a> providing details on what you think is wrong with Behavioral-Responses.</p> <p>If you want to <strong>request an enhancement</strong>, create a new issue <a href="https://github.com/open-source-economics/Behavioral-Responses/issues">here</a> providing details on what you think should be added to Behavioral-Responses.</p> <p>If you want to <strong>propose code changes</strong>, follow the directions in the <a href="https://taxcalc.readthedocs.io/en/latest/contributor_guide.html">Tax-Calculator Contributor Guide</a> on how to fork and clone the Behavioral-Responses git repository. Before developing any code changes be sure to read completely the Tax-Calculator Contributor Guide and then read about the <a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow">Tax-Calculator pull-request workflow</a>. When reading both documents, be sure to mentally substitute Behavioral-Response for Tax-Calculator and behresp for taxcalc.</p> <p>The Behavioral-Responses <a href="https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md#tax-calculator-release-history">release history</a> provides a high-level summary of past pull requests and access to a complete list of merged, closed, and pending pull requests.</p> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Contributor Guide</h4>
+                        <p><p>If you want to <strong>report a bug</strong>, create a new issue <a href="https://github.com/open-source-economics/Behavioral-Responses/issues">here</a> providing details on what you think is wrong with Behavioral-Responses.</p> <p>If you want to <strong>request an enhancement</strong>, create a new issue <a href="https://github.com/open-source-economics/Behavioral-Responses/issues">here</a> providing details on what you think should be added to Behavioral-Responses.</p> <p>If you want to <strong>propose code changes</strong>, follow the directions in the <a href="https://taxcalc.readthedocs.io/en/latest/contributor_guide.html">Tax-Calculator Contributor Guide</a> on how to fork and clone the Behavioral-Responses git repository. Before developing any code changes be sure to read completely the Tax-Calculator Contributor Guide and then read about the <a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow">Tax-Calculator pull-request workflow</a>. When reading both documents, be sure to mentally substitute Behavioral-Response for Tax-Calculator and behresp for taxcalc.</p> <p>The Behavioral-Responses <a href="https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md#tax-calculator-release-history">release history</a> provides a high-level summary of past pull requests and access to a complete list of merged, closed, and pending pull requests.</p> </p>
+                        
+                            <p><a href=https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md >[source]</a></p>
+                        
+                    
+                
+                    
+                        <h4> Unit Tests</h4>
+                        <p><a href="https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests">https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests</a> </p>
+                        
+                    
+                
+                    
+                        <h4> Integration Tests</h4>
+                        <p><a href="https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests">https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests</a> </p>
+                        
+                    
+                
+                    
+                
+                    
+                
+                    
+                        <h4> Link to webapp</h4>
+                        <p><a href="https://www.ospc.org/taxbrain/">https://www.ospc.org/taxbrain/</a> </p>
+                        
+                    
+                
+                    
+                        <h4> Public Issue Tracker</h4>
+                        <p><a href="https://github.com/open-source-economics/Behavioral-Responses/issues">https://github.com/open-source-economics/Behavioral-Responses/issues</a> </p>
+                        
+                    
+                
+                    
+                        <h4> Public Q & A</h4>
+                        <p><a href="https://github.com/open-source-economics/Behavioral-Responses/issues">https://github.com/open-source-economics/Behavioral-Responses/issues</a> </p>
+                        
+                    
+                
+            </div>
+        </div>
+    </body>
+</html>

--- a/Catalog/Tax-Calculator.html
+++ b/Catalog/Tax-Calculator.html
@@ -46,14 +46,14 @@
         <div class="container">
             <div class="jumbotron model-info">
                 <h1 class="display-4">Tax-Calculator</h1>
-                <p class="lead"><p>Federal Individual Income and Payroll Tax Microsimulation Model</p></p>
+                <p class="lead"><p>USA federal individual income and payroll tax microsimulation model</p></p>
                 <hr class="my-4">
                 
                     
                 
                     
                         <h4> Project Overview</h4>
-                        <p><p>Tax-Calculator simulates the US federal individual income and payroll tax system.  In conjunction with micro data that represent the US population and a set of behavioral assumptions, Tax-Calculator can be used to conduct revenue scoring and distributional analyses of tax policies.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p> </p>
+                        <p><p>Tax-Calculator simulates the USA federal individual income and payroll tax system.  In conjunction with micro data that represent the USA population, Tax-Calculator can be used to estimate the aggregate revenue and distributional effects of tax reforms under static analysis assumptions.  In conjunction with other modules, Tax-Calculator can be used to estimate reform effects under a range of non-static assumptions.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p> </p>
                         
                             <p><a href=https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md >[source]</a></p>
                         
@@ -79,15 +79,11 @@
                         <h4> User Documentation</h4>
                         <p><a href="http://open-source-economics.github.io/Tax-Calculator/index.html">http://open-source-economics.github.io/Tax-Calculator/index.html</a> </p>
                         
-                            <p><a href=http://open-source-economics.github.io/Tax-Calculator/index.html >[source]</a></p>
-                        
                     
                 
                     
                         <h4> User Changelog Recent</h4>
                         <p><a href="http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew">http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew</a> </p>
-                        
-                            <p><a href=http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew >[source]</a></p>
                         
                     
                 
@@ -103,7 +99,7 @@
                 
                     
                         <h4> Disclaimer</h4>
-                        <p><p>Results will change as the underlying models improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p> </p>
+                        <p><p>Results will change as model data and logic improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p> </p>
                         
                             <p><a href=https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md >[source]</a></p>
                         
@@ -137,15 +133,11 @@
                         <h4> Unit Tests</h4>
                         <p><a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a> </p>
                         
-                            <p><a href=https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests >[source]</a></p>
-                        
                     
                 
                     
                         <h4> Integration Tests</h4>
                         <p><a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a> </p>
-                        
-                            <p><a href=https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests >[source]</a></p>
                         
                     
                 

--- a/Catalog/catalog.json
+++ b/Catalog/catalog.json
@@ -93,6 +93,100 @@
             "value": "<a href=\"https://github.com/open-source-economics/B-Tax/tree/master/btax/tests\">https://github.com/open-source-economics/B-Tax/tree/master/btax/tests</a>"
         }
     },
+    "Behavioral-Responses": {
+        "name": {
+            "value": "Behavioral-Responses",
+            "source": ""
+        },
+        "project_one_line": {
+            "source": null,
+            "value": "<p>Partial-equilibrium behavioral-responses module that works with Tax-Calculator</p>"
+        },
+        "key_features": {
+            "source": null,
+            "value": null
+        },
+        "project_overview": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md",
+            "value": "<p>Behavioral-Responses, which is part of the Policy Simulation Library (PSL) collection of USA tax models, estimates partial-equilibrium behavioral responses to changes in the US federal individual income and payroll tax system as simulated by <a href=\"https://github.com/open-source-economics/Tax-Calculator\">Tax-Calculator</a></p>"
+        },
+        "citation": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md",
+            "value": "<p>Please cite the source of your analysis as \"Behavioral-Responses release #.#.#, author's calculations.\" If you wish to link to Behavioral-Responses, https://open-source-economics.github.io/Behavioral-Responses/ is preferred.  Additionally, we strongly recommend that you describe the elasticity assumptions used, and provide a link to the materials required to replicate your analysis or, at least, note that those materials are available upon request.</p>"
+        },
+        "license": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/LICENSE.md",
+            "value": "<p>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</p>"
+        },
+        "user_documentation": {
+            "source": null,
+            "value": "<a href=\"http://open-source-economics.github.io/Behavioral-Responses/index.html\">http://open-source-economics.github.io/Behavioral-Responses/index.html</a>"
+        },
+        "user_changelog": {
+            "source": null,
+            "value": null
+        },
+        "user_changelog_recent": {
+            "source": null,
+            "value": null
+        },
+        "dev_changelog": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md",
+            "value": "<p>Go <a href=\"https://github.com/open-source-economics/Behavioral-Responses/pulls?q=is%3Apr+is%3Aclosed\">here</a> for a complete commit history.</p> <h5>2018-11-13 Release 0.4.0</h5> <p>(last merged pull request is <a href=\"https://github.com/open-source-economics/Behavioral-Responses/pull/21\">#21</a>)</p> <p><strong>API Changes</strong></p> <ul> <li> <p>Change documentation to state that Behavioral-Responses <code>behresp</code> packages are available <strong>only</strong> via the <code>PSLmodels</code> Anaconda Cloud channel   [<a href=\"https://github.com/open-source-economics/Behavioral-Responses/pull/20\">#20</a>   by Martin Holmer]</p> </li> <li> <p>Remove <code>versioneer.py</code> and <code>taxcalc/_version.py</code> and related code now that Package-Builder is handling version specification   [<a href=\"https://github.com/open-source-economics/Behavioral-Responses/pull/21\">#21</a>   by Martin Holmer]</p> </li> </ul> <p><strong>New Features</strong></p> <ul> <li>None</li> </ul> <p><strong>Bug Fixes</strong></p> <ul> <li>None</li> </ul>"
+        },
+        "disclaimer": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md",
+            "value": "<p>Results will change as the underlying models improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p>"
+        },
+        "user_case_studies": {
+            "source": null,
+            "value": null
+        },
+        "project_roadmap": {
+            "source": null,
+            "value": null
+        },
+        "contributor_overview": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md",
+            "value": "<p>If you want to <strong>report a bug</strong>, create a new issue <a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">here</a> providing details on what you think is wrong with Behavioral-Responses.</p> <p>If you want to <strong>request an enhancement</strong>, create a new issue <a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">here</a> providing details on what you think should be added to Behavioral-Responses.</p> <p>If you want to <strong>propose code changes</strong>, follow the directions in the <a href=\"https://taxcalc.readthedocs.io/en/latest/contributor_guide.html\">Tax-Calculator Contributor Guide</a> on how to fork and clone the Behavioral-Responses git repository. Before developing any code changes be sure to read completely the Tax-Calculator Contributor Guide and then read about the <a href=\"https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow\">Tax-Calculator pull-request workflow</a>. When reading both documents, be sure to mentally substitute Behavioral-Response for Tax-Calculator and behresp for taxcalc.</p> <p>The Behavioral-Responses <a href=\"https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md#tax-calculator-release-history\">release history</a> provides a high-level summary of past pull requests and access to a complete list of merged, closed, and pending pull requests.</p>"
+        },
+        "contributor_guide": {
+            "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/README.md",
+            "value": "<p>If you want to <strong>report a bug</strong>, create a new issue <a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">here</a> providing details on what you think is wrong with Behavioral-Responses.</p> <p>If you want to <strong>request an enhancement</strong>, create a new issue <a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">here</a> providing details on what you think should be added to Behavioral-Responses.</p> <p>If you want to <strong>propose code changes</strong>, follow the directions in the <a href=\"https://taxcalc.readthedocs.io/en/latest/contributor_guide.html\">Tax-Calculator Contributor Guide</a> on how to fork and clone the Behavioral-Responses git repository. Before developing any code changes be sure to read completely the Tax-Calculator Contributor Guide and then read about the <a href=\"https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow\">Tax-Calculator pull-request workflow</a>. When reading both documents, be sure to mentally substitute Behavioral-Response for Tax-Calculator and behresp for taxcalc.</p> <p>The Behavioral-Responses <a href=\"https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md#tax-calculator-release-history\">release history</a> provides a high-level summary of past pull requests and access to a complete list of merged, closed, and pending pull requests.</p>"
+        },
+        "governance_overview": {
+            "source": null,
+            "value": null
+        },
+        "public_funding": {
+            "source": null,
+            "value": null
+        },
+        "link_to_webapp": {
+            "source": null,
+            "value": "<a href=\"https://www.ospc.org/taxbrain/\">https://www.ospc.org/taxbrain/</a>"
+        },
+        "public_issue_tracker": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">https://github.com/open-source-economics/Behavioral-Responses/issues</a>"
+        },
+        "public_qanda": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">https://github.com/open-source-economics/Behavioral-Responses/issues</a>"
+        },
+        "core_maintainers": {
+            "source": null,
+            "value": "<ul><li>Martin Holmer</li><li>Matt Jensen</li></ul>"
+        },
+        "unit_test": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests\">https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests</a>"
+        },
+        "integration_test": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests\">https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests</a>"
+        }
+    },
     "OG-USA": {
         "name": {
             "value": "OG-USA",
@@ -193,8 +287,8 @@
             "source": ""
         },
         "project_one_line": {
-            "source": "https://github.com/open-source-economics/Tax-Calculator",
-            "value": "<p>Federal Individual Income and Payroll Tax Microsimulation Model</p>"
+            "source": null,
+            "value": "<p>USA federal individual income and payroll tax microsimulation model</p>"
         },
         "key_features": {
             "source": null,
@@ -202,7 +296,7 @@
         },
         "project_overview": {
             "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md",
-            "value": "<p>Tax-Calculator simulates the US federal individual income and payroll tax system.  In conjunction with micro data that represent the US population and a set of behavioral assumptions, Tax-Calculator can be used to conduct revenue scoring and distributional analyses of tax policies.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p>"
+            "value": "<p>Tax-Calculator simulates the USA federal individual income and payroll tax system.  In conjunction with micro data that represent the USA population, Tax-Calculator can be used to estimate the aggregate revenue and distributional effects of tax reforms under static analysis assumptions.  In conjunction with other modules, Tax-Calculator can be used to estimate reform effects under a range of non-static assumptions.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p>"
         },
         "citation": {
             "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md",
@@ -213,7 +307,7 @@
             "value": "<p>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</p>"
         },
         "user_documentation": {
-            "source": "http://open-source-economics.github.io/Tax-Calculator/index.html",
+            "source": null,
             "value": "<a href=\"http://open-source-economics.github.io/Tax-Calculator/index.html\">http://open-source-economics.github.io/Tax-Calculator/index.html</a>"
         },
         "user_changelog": {
@@ -221,7 +315,7 @@
             "value": null
         },
         "user_changelog_recent": {
-            "source": "http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew",
+            "source": null,
             "value": "<a href=\"http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew\">http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew</a>"
         },
         "dev_changelog": {
@@ -230,7 +324,7 @@
         },
         "disclaimer": {
             "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md",
-            "value": "<p>Results will change as the underlying models improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p>"
+            "value": "<p>Results will change as model data and logic improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p>"
         },
         "user_case_studies": {
             "source": null,
@@ -273,11 +367,11 @@
             "value": "<ul><li>Martin Holmer</li><li>Matt Jensen</li></ul>"
         },
         "unit_test": {
-            "source": "https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests",
+            "source": null,
             "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests\">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a>"
         },
         "integration_test": {
-            "source": "https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests",
+            "source": null,
             "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests\">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a>"
         }
     }

--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -30,8 +30,17 @@
         <div class="container">
             <h1>Models</h1>
             
+                <h3><a href="B-Tax.html" style="color:inherit;">B-Tax</a></h3>
+                <p><p>B-Tax is a model that can be used to evaluate the effect of US federal taxes on the investment incentives of corporate and non-corporate businesses.  Specifically, B-Tax uses data on the business assets and financial policy, as well as microdata on individual tax filers, to compute marginal effective tax rates on new investments.  In modeling the effects of changes to the individual income tax code, B-Tax works with <a href="https://github.com/open-source-economics/tax-calculator">Tax-Calculator</a>, another open source model of US federal tax policy.  B-Tax is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p></p>
+            
+                <h3><a href="Behavioral-Responses.html" style="color:inherit;">Behavioral-Responses</a></h3>
+                <p><p>Behavioral-Responses, which is part of the Policy Simulation Library (PSL) collection of USA tax models, estimates partial-equilibrium behavioral responses to changes in the US federal individual income and payroll tax system as simulated by <a href="https://github.com/open-source-economics/Tax-Calculator">Tax-Calculator</a></p></p>
+            
                 <h3><a href="OG-USA.html" style="color:inherit;">OG-USA</a></h3>
                 <p><p>OG-USA is an overlapping-generations (OG) model of the economy of the United States (USA) that allows for dynamic general equilibrium analysis of federal tax policy. The model output focuses changes in macroeconomic aggregates (GDP, investment, consumption), wages, interest rates, and the stream of tax revenues over time. Careful documentation of the model--its output, and solution method--is available <a href="https://github.com/rickecon/OG-USA/blob/doc/documentation/OGUSAdoc.pdf">here</a> and is regularly updated.</p></p>
+            
+                <h3><a href="Tax-Calculator.html" style="color:inherit;">Tax-Calculator</a></h3>
+                <p><p>Tax-Calculator simulates the USA federal individual income and payroll tax system.  In conjunction with micro data that represent the USA population, Tax-Calculator can be used to estimate the aggregate revenue and distributional effects of tax reforms under static analysis assumptions.  In conjunction with other modules, Tax-Calculator can be used to estimate reform effects under a range of non-static assumptions.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p></p>
             
         </div>
     </body>

--- a/Catalog/index.html
+++ b/Catalog/index.html
@@ -30,14 +30,8 @@
         <div class="container">
             <h1>Models</h1>
             
-                <h3><a href="B-Tax.html" style="color:inherit;">B-Tax</a></h3>
-                <p><p>B-Tax is a model that can be used to evaluate the effect of US federal taxes on the investment incentives of corporate and non-corporate businesses.  Specifically, B-Tax uses data on the business assets and financial policy, as well as microdata on individual tax filers, to compute marginal effective tax rates on new investments.  In modeling the effects of changes to the individual income tax code, B-Tax works with <a href="https://github.com/open-source-economics/tax-calculator">Tax-Calculator</a>, another open source model of US federal tax policy.  B-Tax is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p></p>
-            
                 <h3><a href="OG-USA.html" style="color:inherit;">OG-USA</a></h3>
                 <p><p>OG-USA is an overlapping-generations (OG) model of the economy of the United States (USA) that allows for dynamic general equilibrium analysis of federal tax policy. The model output focuses changes in macroeconomic aggregates (GDP, investment, consumption), wages, interest rates, and the stream of tax revenues over time. Careful documentation of the model--its output, and solution method--is available <a href="https://github.com/rickecon/OG-USA/blob/doc/documentation/OGUSAdoc.pdf">here</a> and is regularly updated.</p></p>
-            
-                <h3><a href="Tax-Calculator.html" style="color:inherit;">Tax-Calculator</a></h3>
-                <p><p>Tax-Calculator simulates the US federal individual income and payroll tax system.  In conjunction with micro data that represent the US population and a set of behavioral assumptions, Tax-Calculator can be used to conduct revenue scoring and distributional analyses of tax policies.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p></p>
             
         </div>
     </body>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) for transparancy. Modeling projects may also adopt PSL's criteria for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains.
+The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to [PSL criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) for transparency. Modeling projects may also adopt PSL's criteria for interoperability and community building, which take the form of suggestions for interface design and organizational activity. PSL aims to grow to span governments and policy domains.
 
 The PSL project, which lives in this repository, sets PSL criteria and develops infrastructure to support PSL.
 

--- a/Tools/Catalog-Builder/register.json
+++ b/Tools/Catalog-Builder/register.json
@@ -13,5 +13,10 @@
         "org": "open-source-economics",
         "repo": "Tax-Calculator",
         "branch": "master"
+    },
+     {
+        "org": "open-source-economics",
+        "repo": "Behavioral-Responses",
+        "branch": "master"
     }
 ]

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                                 About PSL
                             </div>
                             <div class="card-body">
-                                <p>The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to PSL Criteria for transparancy.</p>
+                                <p>The Policy Simulation Library (PSL) is an open source software library for public-policy decisionmaking. The models in PSL are developed by independent projects that conform to PSL Criteria for transparency.</p>
                             </div>
                         </div>
                     </a>


### PR DESCRIPTION
This PR adds the [Behavioral-Responses](https://github.com/open-source-economics/Behavioral-Responses) model to the PSL catalog and updates the Tax-Calculator catalog card.

Additionally, this PR fixes a typo in the PSL `README.md` (changes "transparancy" to "transparency")

cc: @martinholmer @MattHJensen @hdoupe @andersonfrailey 