### PR TITLE
correct link to register.json

### DIFF
--- a/Community/contribute.md
+++ b/Community/contribute.md
@@ -6,7 +6,7 @@ When you feel that you have made a valuable contribution, please add it to RELEA
 
 ## Submitting a project to PSL
 
-To submit a public policy simulation project to PSL, please bring your model or data preparation routine into compliance with [PSL Criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) and then open a pull request to PSL adding your model to the [PSL Catalog Register](https://github.com/open-source-economics/PSL/blob/master/Catalog/register.json). The PSL project will then review your PR. If you have a question about the process or are unsure of your project's relevance to PSL, please open an [issue](https://github.com/open-source-economics/PSL/issues). 
+To submit a public policy simulation project to PSL, please bring your model or data preparation routine into compliance with [PSL Criteria](https://github.com/open-source-economics/PSL/blob/master/Criteria/library_criteria.md) and then open a pull request to PSL adding your model to the [PSL Catalog Register](https://github.com/open-source-economics/PSL/blob/master/Tools/Catalog-Builder/register.json). The PSL project will then review your PR. If you have a question about the process or are unsure of your project's relevance to PSL, please open an [issue](https://github.com/open-source-economics/PSL/issues). 
 
 ## Office hours with the community
 


### PR DESCRIPTION
This PR fixes a broken link to register.json. I am opening a separate issue for the discussion of where register.json should be located. 