### PR TITLE
update catalog

### DIFF
--- a/Catalog/Tax-Calculator.html
+++ b/Catalog/Tax-Calculator.html
@@ -77,23 +77,21 @@
                 
                     
                         <h4> User Documentation</h4>
-                        <p><a href="http://open-source-economics.github.io/Tax-Calculator/index.html">http://open-source-economics.github.io/Tax-Calculator/index.html</a> </p>
+                        <p><a href="http://open-source-economics.github.io/Tax-Calculator/index.html">User Documentation</a> </p>
                         
                     
                 
                     
-                        <h4> User Changelog Recent</h4>
-                        <p><a href="http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew">http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew</a> </p>
-                        
-                    
                 
+                    
+                        <h4> User Changelog</h4>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/CHANGES.md#tax-calculator-change-history">Tax-Calculator Change History</a> </p>
+                        
                     
                 
                     
                         <h4> Developer Changelog</h4>
-                        <p><p>Go <a href="https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Apr+is%3Aclosed">here</a> for a complete commit history.</p> <h5>2018-11-13 Release 0.23.0</h5> <p>(last merged pull request is <a href="https://github.com/open-source-economics/Tax-Calculator/pull/2111">#2111</a>)</p> <p><strong>API Changes</strong></p> <ul> <li> <p>Remove confusing <code>filer</code> variable from list of usable input variables   [<a href="https://github.com/open-source-economics/Tax-Calculator/pull/2102">#2102</a>   by Martin Holmer]</p> </li> <li> <p>Remove useless <code>start_year</code> and <code>num_years</code> arguments of constructor for the Policy, Consumption, and GrowDiff classes   [<a href="https://github.com/open-source-economics/Tax-Calculator/pull/2103">#2103</a>   by Martin Holmer]</p> </li> <li> <p>Add deprecated warning to Behavior class constructor and documentation because Behavior class will be removed from Tax-Calculator in a future release   [<a href="https://github.com/open-source-economics/Tax-Calculator/pull/2105">#2105</a>   by Martin Holmer]</p> </li> <li> <p>Remove <code>versioneer.py</code> and <code>taxcalc/_version.py</code> and related code now that Package-Builder is handling version specification   [<a href="https://github.com/open-source-economics/Tax-Calculator/pull/2111">#2111</a>   by Martin Holmer]</p> </li> </ul> <p><strong>New Features</strong></p> <ul> <li>Revise Cookbook recipe 2 to show use of new Behavioral-Responses behresp package as alternative to deprecated Behavior class   [<a href="https://github.com/open-source-economics/Tax-Calculator/pull/2107">#2107</a>   by Martin Holmer]</li> </ul> <p><strong>Bug Fixes</strong></p> <ul> <li>None</li> </ul> </p>
-                        
-                            <p><a href=https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md >[source]</a></p>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#tax-calculator-release-history">Tax-Calculator Release History</a> </p>
                         
                     
                 
@@ -107,6 +105,10 @@
                 
                     
                 
+                    
+                        <h4> Project Roadmap</h4>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/ROADMAP.md#plans-for-future-tax-calculator-development">PLANS FOR FUTURE TAX-CALCULATOR DEVELOPMENT</a> </p>
+                        
                     
                 
                     
@@ -125,19 +127,19 @@
                 
                     
                         <h4> Contributor Guide</h4>
-                        <p><a href="https://taxcalc.readthedocs.io/en/latest/contributor_guide.html">https://taxcalc.readthedocs.io/en/latest/contributor_guide.html</a> </p>
+                        <p><a href="https://taxcalc.readthedocs.io/en/latest/contributor_guide.html">Contributor Guide</a> </p>
                         
                     
                 
                     
                         <h4> Unit Tests</h4>
-                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a> </p>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests"><kbd>pytest</kbd> Unit Tests</a> </p>
                         
                     
                 
                     
                         <h4> Integration Tests</h4>
-                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a> </p>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests"><kbd>pytest</kbd> Unit Tests</a> </p>
                         
                     
                 
@@ -147,19 +149,19 @@
                 
                     
                         <h4> Link to webapp</h4>
-                        <p><a href="https://www.ospc.org/taxbrain/">https://www.ospc.org/taxbrain/</a> </p>
+                        <p><a href="https://www.ospc.org/taxbrain/">TaxBrain</a> </p>
                         
                     
                 
                     
                         <h4> Public Issue Tracker</h4>
-                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/issues">https://github.com/open-source-economics/Tax-Calculator/issues</a> </p>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/issues">Issues</a> </p>
                         
                     
                 
                     
                         <h4> Public Q & A</h4>
-                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/issues">https://github.com/open-source-economics/Tax-Calculator/issues</a> </p>
+                        <p><a href="https://github.com/open-source-economics/Tax-Calculator/issues">Issues</a> </p>
                         
                     
                 

--- a/Catalog/catalog.json
+++ b/Catalog/catalog.json
@@ -290,10 +290,6 @@
             "source": null,
             "value": "<p>USA federal individual income and payroll tax microsimulation model</p>"
         },
-        "key_features": {
-            "source": null,
-            "value": null
-        },
         "project_overview": {
             "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md",
             "value": "<p>Tax-Calculator simulates the USA federal individual income and payroll tax system.  In conjunction with micro data that represent the USA population, Tax-Calculator can be used to estimate the aggregate revenue and distributional effects of tax reforms under static analysis assumptions.  In conjunction with other modules, Tax-Calculator can be used to estimate reform effects under a range of non-static assumptions.  Tax-Calculator is written in Python, an interpreted language that can execute on Windows, Mac, or Linux.</p>"
@@ -308,31 +304,27 @@
         },
         "user_documentation": {
             "source": null,
-            "value": "<a href=\"http://open-source-economics.github.io/Tax-Calculator/index.html\">http://open-source-economics.github.io/Tax-Calculator/index.html</a>"
+            "value": "<a href=\"http://open-source-economics.github.io/Tax-Calculator/index.html\">User Documentation</a>"
         },
         "user_changelog": {
             "source": null,
-            "value": null
-        },
-        "user_changelog_recent": {
-            "source": null,
-            "value": "<a href=\"http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew\">http://open-source-economics.github.io/Tax-Calculator/index.html#whatsnew</a>"
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/blob/master/CHANGES.md#tax-calculator-change-history\">Tax-Calculator Change History</a>"
         },
         "dev_changelog": {
-            "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md",
-            "value": "<p>Go <a href=\"https://github.com/open-source-economics/Tax-Calculator/pulls?q=is%3Apr+is%3Aclosed\">here</a> for a complete commit history.</p> <h5>2018-11-13 Release 0.23.0</h5> <p>(last merged pull request is <a href=\"https://github.com/open-source-economics/Tax-Calculator/pull/2111\">#2111</a>)</p> <p><strong>API Changes</strong></p> <ul> <li> <p>Remove confusing <code>filer</code> variable from list of usable input variables   [<a href=\"https://github.com/open-source-economics/Tax-Calculator/pull/2102\">#2102</a>   by Martin Holmer]</p> </li> <li> <p>Remove useless <code>start_year</code> and <code>num_years</code> arguments of constructor for the Policy, Consumption, and GrowDiff classes   [<a href=\"https://github.com/open-source-economics/Tax-Calculator/pull/2103\">#2103</a>   by Martin Holmer]</p> </li> <li> <p>Add deprecated warning to Behavior class constructor and documentation because Behavior class will be removed from Tax-Calculator in a future release   [<a href=\"https://github.com/open-source-economics/Tax-Calculator/pull/2105\">#2105</a>   by Martin Holmer]</p> </li> <li> <p>Remove <code>versioneer.py</code> and <code>taxcalc/_version.py</code> and related code now that Package-Builder is handling version specification   [<a href=\"https://github.com/open-source-economics/Tax-Calculator/pull/2111\">#2111</a>   by Martin Holmer]</p> </li> </ul> <p><strong>New Features</strong></p> <ul> <li>Revise Cookbook recipe 2 to show use of new Behavioral-Responses behresp package as alternative to deprecated Behavior class   [<a href=\"https://github.com/open-source-economics/Tax-Calculator/pull/2107\">#2107</a>   by Martin Holmer]</li> </ul> <p><strong>Bug Fixes</strong></p> <ul> <li>None</li> </ul>"
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/blob/master/RELEASES.md#tax-calculator-release-history\">Tax-Calculator Release History</a>"
         },
         "disclaimer": {
             "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md",
             "value": "<p>Results will change as model data and logic improve. A fundamental reason for adopting open source methods in this project is so that people from all backgrounds can contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the model will produce different results.</p>"
         },
-        "user_case_studies": {
+        "core_maintainers": {
             "source": null,
-            "value": null
+            "value": "<ul><li>Martin Holmer</li><li>Matt Jensen</li></ul>"
         },
         "project_roadmap": {
             "source": null,
-            "value": null
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/blob/master/ROADMAP.md#plans-for-future-tax-calculator-development\">PLANS FOR FUTURE TAX-CALCULATOR DEVELOPMENT</a>"
         },
         "contributor_overview": {
             "source": "https://github.com/open-source-economics/Tax-Calculator/blob/master/README.md",
@@ -340,7 +332,31 @@
         },
         "contributor_guide": {
             "source": null,
-            "value": "<a href=\"https://taxcalc.readthedocs.io/en/latest/contributor_guide.html\">https://taxcalc.readthedocs.io/en/latest/contributor_guide.html</a>"
+            "value": "<a href=\"https://taxcalc.readthedocs.io/en/latest/contributor_guide.html\">Contributor Guide</a>"
+        },
+        "unit_test": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests\"><kbd>pytest</kbd> Unit Tests</a>"
+        },
+        "integration_test": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests\"><kbd>pytest</kbd> Unit Tests</a>"
+        },
+        "link_to_webapp": {
+            "source": null,
+            "value": "<a href=\"https://www.ospc.org/taxbrain/\">TaxBrain</a>"
+        },
+        "public_issue_tracker": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/issues\">Issues</a>"
+        },
+        "public_qanda": {
+            "source": null,
+            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/issues\">Issues</a>"
+        },
+        "key_features": {
+            "source": null,
+            "value": null
         },
         "governance_overview": {
             "source": null,
@@ -350,29 +366,13 @@
             "source": null,
             "value": null
         },
-        "link_to_webapp": {
+        "user_changelog_recent": {
             "source": null,
-            "value": "<a href=\"https://www.ospc.org/taxbrain/\">https://www.ospc.org/taxbrain/</a>"
+            "value": null
         },
-        "public_issue_tracker": {
+        "user_case_studies": {
             "source": null,
-            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/issues\">https://github.com/open-source-economics/Tax-Calculator/issues</a>"
-        },
-        "public_qanda": {
-            "source": null,
-            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/issues\">https://github.com/open-source-economics/Tax-Calculator/issues</a>"
-        },
-        "core_maintainers": {
-            "source": null,
-            "value": "<ul><li>Martin Holmer</li><li>Matt Jensen</li></ul>"
-        },
-        "unit_test": {
-            "source": null,
-            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests\">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a>"
-        },
-        "integration_test": {
-            "source": null,
-            "value": "<a href=\"https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests\">https://github.com/open-source-economics/Tax-Calculator/tree/master/taxcalc/tests</a>"
+            "value": null
         }
     }
 }

--- a/about.html
+++ b/about.html
@@ -46,7 +46,7 @@
 <li>Broadcast-Recipes for disseminating updates about the projects to users.</li>
 <li>A privacy-granting service to repost user questions on our community message boards. For example, "A Congressional user from an important committee would like to know _____."</li>
 </ul>
-<p>The PSL's online home for users is <a href="www.pslmodels.org">https://www.pslmodels.org</a>.</p>
+<p>The PSL's online home for users is <a href="https://www.pslmodels.org">https://www.pslmodels.org</a>.</p>
 <p>If you would like to learn more about PSL plans, see our <a href="https://github.com/open-source-economics/PSL/blob/master/Community/roadmap.md">roadmap</a>.</p>
 <p>If you would like to make a technical contribution to PSL, please review the <a href="https://github.com/open-source-economics/PSL/blob/master/Community/contribute.md">contributor guide</a>.</p>
 <p>You can reach PSL developers and users to discuss how to get started by opening an issue or joining the PSL Community <a href="https://matrix.to/#/!oZnjlINzAXrgdzXEfZ:matrix.org">chat room</a>.</p>


### PR DESCRIPTION
This includes the latest updates to Tax-Calculator and fixes a link in the about page (I fixed the link in the readme in a previous commit). 